### PR TITLE
Fix M-command matching regex

### DIFF
--- a/octoprint_GSLC/__init__.py
+++ b/octoprint_GSLC/__init__.py
@@ -20,7 +20,7 @@ class GCodeSuperLaserController(octoprint.plugin.StartupPlugin,
 
     def __init__(self):
         self.pigClient = pigpio.pi()
-        self.regM = re.compile('M\d')
+        self.regM = re.compile('M\d+')
         self.regS = re.compile('S\d+')
 
     def hook_gcode_queuing(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):


### PR DESCRIPTION
Matching just a single digit also matches, for example, M400, M401, and M402 all as "M4",
which will cause "IndexError: list index out of range" on line 49